### PR TITLE
Support native Steam installations

### DIFF
--- a/gg.minion.Minion.yml
+++ b/gg.minion.Minion.yml
@@ -11,6 +11,7 @@ finish-args:
   - --share=network
   - --persist=.minion
   - --filesystem=~/.steam
+  - --filesystem=~/.local/share/Steam
   - --filesystem=~/.var/app/com.valvesoftware.Steam
   - --filesystem=~/Games
 modules:

--- a/gg.minion.Minion.yml
+++ b/gg.minion.Minion.yml
@@ -10,6 +10,7 @@ finish-args:
   - --socket=x11
   - --share=network
   - --persist=.minion
+  - --filesystem=~/.steam
   - --filesystem=~/.var/app/com.valvesoftware.Steam
   - --filesystem=~/Games
 modules:


### PR DESCRIPTION
Allow for Minion to access the `~/.steam` folder as well for native steam installations.