### PR TITLE
[Chore] Use direct steam path

### DIFF
--- a/gg.minion.Minion.yml
+++ b/gg.minion.Minion.yml
@@ -13,7 +13,7 @@ finish-args:
   - --persist=.minion
   # Steam-specific folders
   - --filesystem=~/.steam
-  - --filesystem=xdg-data/Steam
+  - --filesystem=~/.local/share/Steam
   - --filesystem=~/.var/app/com.valvesoftware.Steam
   # Lutris installations
   - --filesystem=~/Games


### PR DESCRIPTION
`XDG_DATA` path can be changed sometimes but the steam path is always `~/.local/share/Steam`, so the direct path is opted to be used now.