### PR TITLE
Update runtime to 24.08 to resolve EOL warning

### DIFF
--- a/gg.minion.Minion.yml
+++ b/gg.minion.Minion.yml
@@ -1,6 +1,6 @@
 app-id: gg.minion.Minion
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 command: minion.sh
 sdk: org.freedesktop.Sdk
 tags:


### PR DESCRIPTION
The previous manifest used the 23.08 Freedesktop runtime, which is now End-of-Life (EOL). This update switches the runtime-version to 24.08 to restore the application to a supported and secure platform.